### PR TITLE
fix missing oauth,api url and support scopeSeprator by array

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -59,7 +59,7 @@ Strategy.prototype.authenticate = function(req, options) {
 util.inherits(Strategy, OAuth2Strategy);
 
 Strategy.prototype.userProfile = function(accessToken, done) {
-  var url = uri.format(uri.parse(this._profileURL));
+  const url = uri.format(uri.parse(this._profileURL));
 
   this._oauth2.get(url, accessToken, function(err, body, res) {
     if (err) {
@@ -67,9 +67,9 @@ Strategy.prototype.userProfile = function(accessToken, done) {
     }
 
     try {
-      var json = JSON.parse(body);
+      const json = JSON.parse(body);
 
-      var profile = { provider: 'line' };
+      let profile = { provider: 'line' };
       profile.id = json.userId;
       profile.displayName = json.displayName;
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -1,32 +1,39 @@
 // Load modules.
-var OAuth2Strategy = require('passport-oauth2'),
-    shortid = require('shortid'),
-    util = require('util'),
-    uri = require('url'),
-    InternalOAuthError = OAuth2Strategy.InternalOAuthError,
-    LineAuthorizationError = require('./errors/lineAuthorizationError');
+const OAuth2Strategy = require('passport-oauth2'),
+  shortid = require('shortid'),
+  util = require('util'),
+  uri = require('url'),
+  InternalOAuthError = OAuth2Strategy.InternalOAuthError,
+  LineAuthorizationError = require('./errors/lineAuthorizationError'),
+  LINE_OAUTH2_URI = 'https://access.line.me/oauth2/v2.1',
+  LINE_OAUTH2_API_URI = 'https://api.line.me/oauth2/v2.1',
+  LINE_API_URI = 'https://api.line.me/v2';
 
 function Strategy(options, verify) {
   options = options || {};
   options.clientID = options.channelID;
   options.clientSecret = options.channelSecret;
   options.useAutoLogin = options.useAutoLogin || true;
-  options.scopeSeparator = options.scopeSeparator || ',';
-  options.customHeaders = options.customHeaders || {}
+  options.scopeSeparator = options.scopeSeparator || ['openid', 'profile'];
+  options.customHeaders = options.customHeaders || {};
 
   // Delete Clannel ID and Secret.
   delete options.channelID;
   delete options.channelSecret;
 
-  options.authorizationURL = options.authorizationURL || 'https://access.line.me/dialog/oauth/weblogin';
-  options.tokenURL = options.tokenURL || 'https://api.line.me/v2/oauth/accessToken';
+  options.authorizationURL =
+    options.authorizationURL || `${LINE_OAUTH2_URI}/authorize`;
+  options.tokenURL = options.tokenURL || `${LINE_OAUTH2_API_URI}/token`;
 
   // https://developers.line.me/web-api/integrating-web-login-v2#guidance_to_login_screen
-  if (options.useAutoLogin) options.authorizationURL += '?state=' + shortid.generate();
+  if (options.useAutoLogin)
+    options.authorizationURL += `?state=${shortid.generate()}`;
+  if (options.scopeSeparator)
+    options.authorizationURL += `&scope=${options.scopeSeparator.join(' ')}`;
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'line';
-  this._profileURL = options.profileURL || 'https://api.line.me/v2/profile';
+  this._profileURL = options.profileURL || `${LINE_API_URI}/profile`;
   this._profileFields = options.profileFields || null;
   this._clientID = options.clientID;
   this._clientSecret = options.clientSecret;
@@ -36,9 +43,13 @@ function Strategy(options, verify) {
 }
 
 Strategy.prototype.authenticate = function(req, options) {
-
   if (req.query && req.query.error_code && !req.query.error) {
-    return this.error(new LineAuthorizationError(req.query.error_message, parseInt(req.query.error_code, 10)));
+    return this.error(
+      new LineAuthorizationError(
+        req.query.error_message,
+        parseInt(req.query.error_code, 10)
+      )
+    );
   }
 
   OAuth2Strategy.prototype.authenticate.call(this, req, options);
@@ -50,7 +61,7 @@ util.inherits(Strategy, OAuth2Strategy);
 Strategy.prototype.userProfile = function(accessToken, done) {
   var url = uri.format(uri.parse(this._profileURL));
 
-  this._oauth2.get(url, accessToken, function (err, body, res) {
+  this._oauth2.get(url, accessToken, function(err, body, res) {
     if (err) {
       return done(new InternalOAuthError('Failed to fetch user profile', err));
     }
@@ -66,7 +77,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
       profile._json = json;
 
       done(null, profile);
-    } catch(e) {
+    } catch (e) {
       done(e);
     }
   });


### PR DESCRIPTION
### Change missing API

- https://access.line.me/dialog/oauth/weblogin > https://access.line.me/oauth2/v2.1/authorize
- https://api.line.me/v2/oauth/accessToken > https://api.line.me/oauth2/v2.1/token

### Scope Separator Support

scopeSeparator

- default ['openid', 'profile']

```javascript
{
  scopeSeparator: ['openid', 'profile']
}
```