### PR TITLE
Update Strategy.js

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -19,7 +19,6 @@ function Strategy(_options, verify) {
   delete options.botPrompt;
   options.clientID = _options.channelID;
   options.clientSecret = _options.channelSecret;
-  options.state = _options.state || true;
   options.scopeSeparator = _options.scopeSeparator || ' ';
   options.customHeaders = _options.customHeaders || {};
   options.botPrompt = _options.botPrompt || defaultOptions.botPrompt;


### PR DESCRIPTION
the line I've deleted is because if one passes its own state with `passport.authenticate('line', { scope: config.line.scope, state: 'some custome string' })` will receive an error from callback `Unable to verify authorization request state.`

without that line, you can pass your own `state` to it and it returns back in callback query string accordingly.