### PR TITLE
add support for Line login option - prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ passport.use(new LineStrategy({
     callbackURL: "http://localhost:3000/auth/line/callback",
     scope: ['profile', 'openid', 'email'],
     botPrompt: 'normal',
+    prompt: 'consent',
     uiLocales: 'en-US',
   },
   function(accessToken, refreshToken, params, profile, cb) {
@@ -79,6 +80,7 @@ passport.use(new LineStrategy({
 | callbackURL | String | Required | | URL that users are redirected to after authentication and authorization. Must match one of the the callback URLs registered for your channel in the [console](https://developers.line.biz/console/). |
 | scope | Array | Required | `['profile', 'openid']` | Permissions granted by the user. Set value to either profile, openid or email. If  |
 | botPrompt | String | Optional | null | Displays an option to add a bot as a friend during login. Set value to either normal or aggressive. For more information, see [Linking a bot with your LINE Login channel](https://developers.line.biz/en/docs/line-login/web/link-a-bot). |
+| prompt | String | Optional | null | Used to force the consent screen to be displayed even if the user has already granted all requested permissions. For more information, see [Linking a bot with your LINE Login channel](https://developers.line.biz/en/docs/line-login/web/link-a-bot). |
 | uiLocales | String | Optional | null | Display language for LINE Login screens. For more information, see [Linking a bot with your LINE Login channel](https://developers.line.biz/en/docs/line-login/web/integrate-line-login/#spy-making-an-authorization-request). |
 
 ### Response

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -101,7 +101,6 @@ Strategy.prototype.authorizationParams = function(_options) {
   } else {
     delete options.prompt;
   }
-  console.log(_options)
 
   return options;
 };

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -33,6 +33,9 @@ function Strategy(_options, verify) {
   if (!options.uiLocales) {
     delete options.uiLocales;
   }
+  if (!_options.prompt) {
+    delete options.prompt;
+  }
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'line';
@@ -40,6 +43,7 @@ function Strategy(_options, verify) {
   this._clientId = options.clientID;
   this._clientSecret = options.clientSecret;
   this._botPrompt = options.botPrompt;
+  this._prompt = options.prompt;
 
   if (options.uiLocales) {
     this._uiLocales = options.uiLocales;
@@ -92,6 +96,12 @@ Strategy.prototype.authorizationParams = function(_options) {
   if (this._uiLocales) {
     options.ui_locales = this._uiLocales;
   }
+  if (this._prompt === 'consent') {
+    options.prompt = this._prompt;
+  } else {
+    delete options.prompt;
+  }
+  console.log(_options)
 
   return options;
 };

--- a/test/strategy.spec.js
+++ b/test/strategy.spec.js
@@ -146,6 +146,34 @@ test('Set authorization params (botPrompt: normal)', (t) => {
   t.is(newOptions.bot_prompt, options.botPrompt);
 });
 
+test('Set authorization params (prompt: null)', (t) => {
+  const options = {
+    channelID: 'fakeId',
+    channelSecret: 'fakeSecret',
+    callbackURL: 'http://fake.domain',
+    prompt: null
+  };
+
+  const strategy = new LineStrategy(options, () => {});
+  const newOptions = strategy.authorizationParams(options);
+
+  t.is(newOptions.prompt, undefined);
+});
+
+test('Set authorization params (prompt: consent)', (t) => {
+  const options = {
+    channelID: 'fakeId',
+    channelSecret: 'fakeSecret',
+    callbackURL: 'http://fake.domain',
+    botPrompt: 'consent'
+  };
+
+  const strategy = new LineStrategy(options, () => {});
+  const newOptions = strategy.authorizationParams(options);
+
+  t.is(newOptions.prompt, options.prompt);
+});
+
 test('Set authorization params (uiLocales: null)', (t) => {
   const options = {
     channelID: 'fakeId',


### PR DESCRIPTION
making authorization request with query string option - [prompt](https://developers.line.biz/en/docs/line-login/integrate-line-login/#making-an-authorization-request)

## SUMMARY
add support for Line login option **prompt** according to [LINE Document](https://developers.line.biz/en/docs/line-login/integrate-line-login/#making-an-authorization-request)

## HOW TO TEST/REPRODUCE IT?
append **prompt** with value `consent` as one of strategy options